### PR TITLE
Organize standalone R scripts into scripts folder

### DIFF
--- a/scripts/standalone_cbc_preprocessing.R
+++ b/scripts/standalone_cbc_preprocessing.R
@@ -6,7 +6,7 @@ suppressPackageStartupMessages({
 
 #' Preprocess a long-form CBC CSV file.
 #'
-#' Usage: Rscript preprocess_long_form_cbc.R input.csv output_folder/
+#' Usage: Rscript scripts/standalone_cbc_preprocessing.R input.csv output_folder/
 #'
 #' The input file must contain columns:
 #'   PATIENT_ID - Patient identifier
@@ -21,7 +21,7 @@ suppressPackageStartupMessages({
 
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 2) {
-  stop("Usage: Rscript standalone_cbc_preprocessing.R input.csv output_folder/", call. = FALSE)
+  stop("Usage: Rscript scripts/standalone_cbc_preprocessing.R input.csv output_folder/", call. = FALSE)
 }
 
 input_path <- args[1]

--- a/scripts/standalone_make_predictions.R
+++ b/scripts/standalone_make_predictions.R
@@ -8,14 +8,14 @@ suppressPackageStartupMessages({
 
 #' Makes predictions from pre-trained models
 #'
-#' Usage: Rscript standalone_make_predictions.R input.csv models.RDS /output_path
+#' Usage: Rscript scripts/standalone_make_predictions.R input.csv models.RDS /output_path
 #'
 #' The input file must be of the same shape as the output from standalone_cbc_preprocessing.R, while the models should be in list form. 
 
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 2) {
   stop(
-    "Usage: Rscript standalone_make_predictions.R input.csv models.RDS /output_path",
+    "Usage: Rscript scripts/standalone_make_predictions.R input.csv models.RDS /output_path",
     call. = FALSE
   )
 }

--- a/scripts/standalone_simulate_cbc_contamination.R
+++ b/scripts/standalone_simulate_cbc_contamination.R
@@ -6,13 +6,13 @@ suppressPackageStartupMessages({
 
 #' Simulates contamination in a filtered, wide-form, cbc data set
 #'
-#' Usage: Rscript standalone_simulate_cbc_contamination input.csv /output_path
+#' Usage: Rscript scripts/standalone_simulate_cbc_contamination.R input.csv /output_path
 #'
 #' The input file must take the same shape as the output files from standalone_cbc_preprocessing.R
 
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 2) {
-  stop("Usage: Rscript standalone_simulate_cbc_contamination input.csv /output_path", call. = FALSE)
+  stop("Usage: Rscript scripts/standalone_simulate_cbc_contamination.R input.csv /output_path", call. = FALSE)
 }
 
 input_path <- args[1]

--- a/scripts/standalone_train_cbc_ML_models.R
+++ b/scripts/standalone_train_cbc_ML_models.R
@@ -8,14 +8,14 @@ suppressPackageStartupMessages({
 
 #' Trains ML models using simulated CBC contamination
 #'
-#' Usage: Rscript standalone_train_cbc_ML_models.R input.csv /output_path
+#' Usage: Rscript scripts/standalone_train_cbc_ML_models.R input.csv /output_path
 #'
 #' The input file must be of the same shape as the output from standalone_simulate_cbc_contamination.R
 
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 2) {
   stop(
-    "Usage: Rscript standalone_train_cbc_ML_models.R input.csv /output_path",
+    "Usage: Rscript scripts/standalone_train_cbc_ML_models.R input.csv /output_path",
     call. = FALSE
   )
 }


### PR DESCRIPTION
## Summary
- Move standalone preprocessing, simulation, prediction, and model-training scripts into new `scripts` directory.
- Update usage instructions in each script to reference the new location.

## Testing
- `Rscript -e 'lintr::lint_dir("scripts")'` *(fails: command not found)*
- `Rscript -e 'if (requireNamespace("testthat", quietly = TRUE) && dir.exists("tests")) testthat::test_dir("tests") else cat("No tests found\\n")'` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689809936534832da0fce3b1afa1728c