### PR TITLE
Update pipeline script paths

### DIFF
--- a/standalone_predict_pipeline.R
+++ b/standalone_predict_pipeline.R
@@ -33,7 +33,7 @@ message("Preprocessing CBC data...")
 system2(
   "Rscript",
   c(
-    file.path(script_dir, "standalone_cbc_preprocessing.R"),
+    file.path(script_dir, "scripts", "standalone_cbc_preprocessing.R"),
     input_path,
     paste0(script_dir, "/results/")
   )
@@ -50,7 +50,7 @@ message("Generating predictions...")
 system2(
   "Rscript",
   c(
-    file.path(script_dir, "standalone_make_predictions.R"),
+    file.path(script_dir, "scripts", "standalone_make_predictions.R"),
     preproc_out,
     model_path,
     paste0(script_dir, "/results/")

--- a/standalone_train_pipeline.R
+++ b/standalone_train_pipeline.R
@@ -28,7 +28,7 @@ message("Preprocessing CBC data...")
 system2(
   "Rscript",
   c(
-    file.path(script_dir, "standalone_cbc_preprocessing.R"),
+    file.path(script_dir, "scripts", "standalone_cbc_preprocessing.R"),
     input_path,
     paste0(script_dir, "/results/")
   )
@@ -44,7 +44,7 @@ message("Simulating contamination...")
 system2(
   "Rscript",
   c(
-    file.path(script_dir, "standalone_simulate_cbc_contamination.R"),
+    file.path(script_dir, "scripts", "standalone_simulate_cbc_contamination.R"),
     preproc_out,
     paste0(script_dir, "/results/")
   )
@@ -60,7 +60,7 @@ message("Training models...")
 system2(
   "Rscript",
   c(
-    file.path(script_dir, "standalone_train_cbc_ML_models.R"),
+    file.path(script_dir, "scripts", "standalone_train_cbc_ML_models.R"),
     sim_out,
     paste0(script_dir, "/models/")
   )


### PR DESCRIPTION
## Summary
- adjust prediction pipeline to call helper scripts from `scripts/`
- update training pipeline to reference relocated helper scripts

## Testing
- `Rscript -e 'lintr::lint("standalone_predict_pipeline.R")'` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `Rscript -e 'testthat::test_dir("tests")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980ae12704832d93df0cc6c9aaa7a5